### PR TITLE
Implemented icon fix.

### DIFF
--- a/my-app/src/components/Card/Card.js
+++ b/my-app/src/components/Card/Card.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import PlayIcon from '../PlayIcon/PlayIcon';
 import './Card.css'
 
-const Card = ({ info, currentPreviewURL, setPlaying }) => {
+const Card = ({ info, currentPreviewURL, play, setPlaying }) => {
     
     return (
         <div className='py-2 px-4 m-4 border rounded card-view'>
@@ -10,7 +10,7 @@ const Card = ({ info, currentPreviewURL, setPlaying }) => {
             <img src={info.imgSrc} alt={info.name}></img>
             <div className='mt-2'>
                 <h6>{info.artist}</h6>
-                {info.playable && <PlayIcon info={info} currentPreviewURL={currentPreviewURL} setPlaying={setPlaying} />}
+                {info.playable && <PlayIcon info={info} currentPreviewURL={currentPreviewURL} play={play} setPlaying={setPlaying} />}
             </div>
         </div> 
     );

--- a/my-app/src/components/Grid/Grid.js
+++ b/my-app/src/components/Grid/Grid.js
@@ -1,7 +1,7 @@
 import { getItemInfo } from '../../utility/parseMusicItem';
 import Card from '../Card/Card';
 
-const Grid = ({channelItems, currentPreviewURL, setPlaying}) => {
+const Grid = ({channelItems, currentPreviewURL, play, setPlaying}) => {
     console.log("channel items: ", channelItems)
 
     return (
@@ -10,6 +10,7 @@ const Grid = ({channelItems, currentPreviewURL, setPlaying}) => {
             <Card key={index}
                   info={getItemInfo(item)}
                   currentPreviewURL={currentPreviewURL} 
+                  play={play}
                   setPlaying={setPlaying}
              />
              )

--- a/my-app/src/components/Home/Home.js
+++ b/my-app/src/components/Home/Home.js
@@ -24,7 +24,7 @@ function Home() {
       setIsPending(true);
       const newData = query ? 
                       await fetchQuery(query, 1):
-                      await fetchTop(data, channelsOpen, 1);
+                      await fetchTop(data, channelsOpen, 3);
       setIsPending(false);
       setData(newData);
     };
@@ -39,11 +39,11 @@ function Home() {
       {isPending && 'Loading...'}
       {!!Object.keys(data).length && (
       view === 'grid' ?
-      <ViewContainer className='gridView' data={data} channelsOpen={channelsOpen} currentPreviewURL={playing.currentPreviewURL} setPlaying={setPlaying}/>:
-      <ViewContainer className='listView' data={data} channelsOpen={channelsOpen} currentPreviewURL={playing.currentPreviewURL} setPlaying={setPlaying}/>
+      <ViewContainer className='gridView' data={data} channelsOpen={channelsOpen} playing={playing} setPlaying={setPlaying}/>:
+      <ViewContainer className='listView' data={data} channelsOpen={channelsOpen} playing={playing} setPlaying={setPlaying}/>
       )
       }
-      <Player playing={playing}></Player>
+      <Player playing={playing} setPlaying={setPlaying}></Player>
     </div>
   );
 }

--- a/my-app/src/components/List/List.js
+++ b/my-app/src/components/List/List.js
@@ -1,7 +1,7 @@
 import { getItemInfo } from "../../utility/parseMusicItem";
 import PlayIcon from "../PlayIcon/PlayIcon";
 
-const List = ({channelItems, currentPreviewURL, setPlaying}) => {
+const List = ({channelItems, currentPreviewURL, play, setPlaying}) => {
     
     return (
         <div className="list">
@@ -11,7 +11,7 @@ const List = ({channelItems, currentPreviewURL, setPlaying}) => {
                     const info = getItemInfo(item);
                     return (
                     <li key={index}>
-                        {info.playable && <PlayIcon info={info} currentPreviewURL={currentPreviewURL} setPlaying={setPlaying} />}
+                        {info.playable && <PlayIcon info={info} currentPreviewURL={currentPreviewURL} play={play} setPlaying={setPlaying} />}
                         {info.name + (info.artist ? ', ' + info.artist : '')}
                     </li>
                     )

--- a/my-app/src/components/PlayIcon/PlayIcon.js
+++ b/my-app/src/components/PlayIcon/PlayIcon.js
@@ -2,22 +2,14 @@ import { useEffect, useState } from 'react';
 import "./PlayIcon.css";
 
 
-const PlayIcon = ({info, currentPreviewURL, setPlaying}) => {
+const PlayIcon = ({info, currentPreviewURL, play, setPlaying}) => {
     const [icon, setIcon] = useState('bi-play-fill');
 
     useEffect(() => {
-        const needsReset = getNeedsReset(); 
-        if (needsReset) {
-            setIcon('bi-play-fill');
-        }
-    }, [currentPreviewURL]);
-
-    const getNeedsReset = () => {
-        const isNotPlaying = info.previewURL !== currentPreviewURL
-        const iconIsPause = icon === 'bi-pause';
-        const needsReset = isNotPlaying && iconIsPause;
-        return needsReset;
-    };    
+        const currentTrack = info.previewURL === currentPreviewURL;
+        if(currentTrack) play ? setIcon('bi-pause') : setIcon('bi-play-fill');
+        else setIcon('bi-play-fill');
+    }, [currentPreviewURL, play]);   
 
     const getIconClass = () => {
         const isPlaying = info.previewURL === currentPreviewURL;

--- a/my-app/src/components/Player/Player.js
+++ b/my-app/src/components/Player/Player.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import './Player.css';
 
-const Player = ({ playing }) => {
+const Player = ({ playing, setPlaying }) => {
     const { currentPreviewURL , name, artistName, imgSrc, play } = playing;
     const [ volume, setVolume ] = useState(0.2);
 
@@ -27,6 +27,15 @@ const Player = ({ playing }) => {
         setVolume(newVolume);
     };
 
+    const handlePause = (e) => {
+        setPlaying({...playing, play: false});
+    };
+
+    const handlePlay = (e) => {
+        setPlaying({...playing, play: true});
+    };
+
+
     const previousTrack = () => {};
 
     const nextTrack = () => {};
@@ -47,7 +56,7 @@ const Player = ({ playing }) => {
             <span className='region'/>
             {/* <i className='bi-skip-backward' onClick={previousTrack}></i>
             <i className='bi-skip-forward' onClick={nextTrack}></i> */}
-            <audio id='player-audio' src={currentPreviewURL } type='audio/mp3' autoPlay controls></audio>
+            <audio id='player-audio' src={currentPreviewURL } type='audio/mp3' onPause={handlePause} onPlay={handlePlay} autoPlay controls></audio>
             <span className='region'/>
             <input type='range' min='0' max='100' value={volume*100} onChange={handleVolume}/>
         </div>

--- a/my-app/src/components/ViewContainer/ViewContainer.js
+++ b/my-app/src/components/ViewContainer/ViewContainer.js
@@ -2,7 +2,8 @@ import List from '../List/List';
 import Grid from '../Grid/Grid';
 import './ViewContainer.css';
 
-const ViewContainer = ({className, data, channelsOpen, currentPreviewURL, setPlaying}) => {
+const ViewContainer = ({className, data, channelsOpen, playing, setPlaying}) => {
+    const {currentPreviewURL, play} = playing;
     const channelTypes = ['tracks', 'albums', 'artists'];
     const channels = channelTypes.map(type => (
       {
@@ -18,7 +19,8 @@ const ViewContainer = ({className, data, channelsOpen, currentPreviewURL, setPla
         const props = {
             channelItems: channel.items,
             currentPreviewURL,
-            setPlaying
+            setPlaying,
+            play
         }; 
         const GridView = <Grid {...props}/>;
         const ListView = <List {...props}/>; 


### PR DESCRIPTION
Adam's changes looked good. I used them to fix issues the following issues:

- When the user clicked play/pause with the audio controls (as opposed to from the card/list) the corresponding track card/list icon didn't update.
- When the user plays a track and then switches view, the icon of the currently playing track didn't update in the new view.

This change also possibly improves the logic in _PlayIcon.js_ by making it simpler.