### PR TITLE
Completed next track, previous track, and shuffle functionality.

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -26,16 +26,16 @@ const App = () => {
         imgSrc: '', 
         play: false
     });
-    const [favourites, setFavourites] = useState([])
+    const [trackList, setTrackList] = useState()
 
     return (
         <div className='page'>
             <NavBar view={view} setView={setView} searchParams={searchParams} setSearchParams={setSearchParams} filter={filter} setFilter={setFilter}/>
             <Routes>
-                <Route path='/' element={<Home view={view} searchParams={searchParams} filter={filter} playingInfo={playingInfo} setPlayingInfo={setPlayingInfo} />} />
+                <Route path='/' element={<Home view={view} searchParams={searchParams} filter={filter} playingInfo={playingInfo} setPlayingInfo={setPlayingInfo} trackList={trackList} setTrackList={setTrackList} />} />
                 <Route path='/profile' element={<Profile />} />
             </Routes>
-            <Player playingInfo={playingInfo} setPlayingInfo={setPlayingInfo}/>
+            <Player playingInfo={playingInfo} setPlayingInfo={setPlayingInfo} trackList={trackList}/>
         </div>
     )
 };

--- a/my-app/src/components/Grid/Grid.js
+++ b/my-app/src/components/Grid/Grid.js
@@ -4,7 +4,7 @@ import { getItemInfo } from '../../utility/parseMusicItem';
 import Card from '../Card/Card';
 import WrapAlbum from '../WrapAlbum/WrapAlbum';
 
-const Grid = ({channelItems, currentPreviewURL, play, setPlayingInfo, filter}) => {
+const Grid = ({channelItems, currentPreviewURL, play, setPlayingInfo, filter, trackList, setTrackList}) => {
 
     return (
         <div className='gridView'>
@@ -13,7 +13,7 @@ const Grid = ({channelItems, currentPreviewURL, play, setPlayingInfo, filter}) =
                 if (shouldBeFiltered(itemInfo, filter)) return null;
                 const isAlbum = itemInfo.type === 'album';
                 const key = index;
-                const props = {key, itemInfo, currentPreviewURL, play, setPlayingInfo, filter}; 
+                const props = {key, itemInfo, currentPreviewURL, play, setPlayingInfo, filter, trackList, setTrackList}; 
                 const card = <Card {...props}/>;
                 props['card'] = card;
                 props['isCard'] = true;

--- a/my-app/src/components/Home/Home.js
+++ b/my-app/src/components/Home/Home.js
@@ -3,7 +3,7 @@ import { fetchQuery, fetchTop } from '../../utility/fetchNapster';
 import ViewContainer from '../ViewContainer/ViewContainer';
 import './Home.css';
 
-function Home({ view, searchParams, filter, playingInfo, setPlayingInfo }) {
+function Home({ view, searchParams, filter, playingInfo, setPlayingInfo, trackList, setTrackList }) {
   const [data, setData] = useState({});
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState({canRetry: false, message: ''});
@@ -41,8 +41,8 @@ function Home({ view, searchParams, filter, playingInfo, setPlayingInfo }) {
       { !isPending && error && <span>{error.message}</span> }
       {!!Object.keys(data).length && ( 
       view === 'grid' ?
-      <ViewContainer className='gridView' data={data} filter={filter} playingInfo={playingInfo} setPlayingInfo={setPlayingInfo}/>:
-      <ViewContainer className='listView' data={data} filter={filter} playingInfo={playingInfo} setPlayingInfo={setPlayingInfo}/>
+      <ViewContainer className='gridView' data={data} filter={filter} playingInfo={playingInfo} setPlayingInfo={setPlayingInfo} trackList={trackList} setTrackList={setTrackList}/>:
+      <ViewContainer className='listView' data={data} filter={filter} playingInfo={playingInfo} setPlayingInfo={setPlayingInfo} trackList={trackList} setTrackList={setTrackList}/>
       )
       }
     </div>

--- a/my-app/src/components/List/List.js
+++ b/my-app/src/components/List/List.js
@@ -8,7 +8,7 @@ import Card from "../Card/Card";
 import './List.css';
 
 
-const List = ({channelItems, currentPreviewURL, play, setPlayingInfo, filter}) => {
+const List = ({channelItems, currentPreviewURL, play, setPlayingInfo, filter, trackList, setTrackList}) => {
 
     return (
         <div className="list">
@@ -19,7 +19,7 @@ const List = ({channelItems, currentPreviewURL, play, setPlayingInfo, filter}) =
                     if (shouldBeFiltered(itemInfo, filter)) return null;
                     const isAlbum = itemInfo.type === 'album';
                     const key = index;
-                    const props = {key, itemInfo, currentPreviewURL, play, setPlayingInfo, filter}; 
+                    const props = {key, itemInfo, currentPreviewURL, play, setPlayingInfo, filter, trackList, setTrackList}; 
                     const card = <Card {...props}/>;
                     const listItem = <ListItem {...props}/>
                     props['card'] = card;

--- a/my-app/src/components/ViewContainer/ViewContainer.js
+++ b/my-app/src/components/ViewContainer/ViewContainer.js
@@ -3,8 +3,10 @@ import { captilizeFirstLetter } from '../../utility/formatStr';
 import List from '../List/List';
 import Grid from '../Grid/Grid';
 import './ViewContainer.css';
+import { formatAsTrackList } from '../../utility/parseMusicItem';
+import { useEffect } from 'react';
 
-const ViewContainer = ({className, data, filter, playingInfo, setPlayingInfo}) => {
+const ViewContainer = ({className, data, filter, playingInfo, setPlayingInfo, trackList, setTrackList}) => {
     const {currentPreviewURL, play} = playingInfo;
     const channelTypes = ['tracks', 'albums', 'artists'];
     const channels = channelTypes.map(type => (
@@ -16,6 +18,10 @@ const ViewContainer = ({className, data, filter, playingInfo, setPlayingInfo}) =
       )
     ); 
 
+    useEffect(() => {
+        setTrackList(formatAsTrackList(channels[0].items));
+    }, []);
+
     const getView = (channel) => {
         const isGridView = className === 'gridView';
         const props = {
@@ -23,7 +29,9 @@ const ViewContainer = ({className, data, filter, playingInfo, setPlayingInfo}) =
             currentPreviewURL,
             setPlayingInfo,
             play,
-            filter
+            filter,
+            trackList,
+            setTrackList
         };
         const GridView = <Grid {...props}/>;
         const ListView = <List {...props}/>; 

--- a/my-app/src/components/WrapAlbum/WrapAlbum.js
+++ b/my-app/src/components/WrapAlbum/WrapAlbum.js
@@ -1,17 +1,23 @@
 import { useEffect, useState } from 'react'
 import { fetchAlbumTracks, fetchGenre, fetchArtists } from '../../utility/fetchNapster' 
 import { listArrOfStrsAsStr } from '../../utility/formatArr';
+import { formatAsTrackList } from '../../utility/parseMusicItem';
 
 import Dialog from '../Dialog/Dialog';
 import List from '../List/List'
 
 import './WrapAlbum.css'
 
-const WrapAlbum = ({children, card, itemInfo, currentPreviewURL, play, setPlayingInfo, filter, isCard}) => {
+const WrapAlbum = ({children, card, itemInfo, currentPreviewURL, play, setPlayingInfo, filter, isCard, trackList, setTrackList}) => {
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [tracks, setTracks] = useState([]);
     const [genres, setGenres] = useState([]);
     const [features, setFeatures] = useState([]);
+    const [prevTrackList, setPrevTrackList] = useState();
+
+    useEffect(() => {
+        if(trackList && !prevTrackList) setPrevTrackList(trackList);
+    }, [trackList]);
 
     useEffect(() => {
         const updateAlbumInfo = async () => {
@@ -142,7 +148,7 @@ const WrapAlbum = ({children, card, itemInfo, currentPreviewURL, play, setPlayin
 
     const getIsAlbumInfoLoaded = () => {
         const isAlbumInfoLoaded = !!tracks.length; 
-        return isAlbumInfoLoaded; 
+        return isAlbumInfoLoaded && prevTrackList; 
     }
 
     const getWrappedAlbumItemClassName = () => {
@@ -163,12 +169,17 @@ const WrapAlbum = ({children, card, itemInfo, currentPreviewURL, play, setPlayin
 
     const handleCloseDialog = () => {
         setIsDialogOpen(false);
+        setTrackList(prevTrackList);
     };
     
      
     const handleClick = async () => {
         const isAlbumInfoLoaded = getIsAlbumInfoLoaded(); 
-        if (isAlbumInfoLoaded) setIsDialogOpen(true);
+        if (isAlbumInfoLoaded) {
+            setIsDialogOpen(true);
+            const newTrackList = formatAsTrackList(tracks);
+            setTrackList(newTrackList);
+        }
     };
 
 
@@ -194,7 +205,7 @@ const WrapAlbum = ({children, card, itemInfo, currentPreviewURL, play, setPlayin
                     <List 
                         filter={filter}
                         channelItems={tracks} 
-                        itemInfo={itemInfo} 
+                        itemInfo={itemInfo} // Safe to remove?
                         currentPreviewURL={currentPreviewURL} 
                         play={play}
                         setPlayingInfo={setPlayingInfo}

--- a/my-app/src/utility/parseMusicItem.js
+++ b/my-app/src/utility/parseMusicItem.js
@@ -101,4 +101,17 @@ export const getItemInfo = (item) => {
       releaseDate,
       features
     };
-  };
+};
+
+export const formatAsTrackList = (items) => {
+    return items.map(item => {
+        const info = getItemInfo(item);
+        return {
+            currentPreviewURL: info.previewURL,
+            name: info.name,
+            artistName: info.artist,
+            imgSrc: info.imgSrc,
+            play: false
+        }
+    })
+}


### PR DESCRIPTION
Before anyone else works on the project, could you please have a look at this and merge it. 

I implemented next track, previous track, shuffle and the ability for the track to be automatically chosen once the current one ends (either next track or shuffle). This works for the home view and on the dialog view with album tracks. I know Adam you mentioned that this should be implemented for user tracks and playlists, but I still believe this is a good addition for the home and dialog view. Also with the way it has been implemented it should be really easy to add this functionality later to user playlists or favourites list.